### PR TITLE
Create additional private group categories on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ We welcome you to make this first step and make your first pull request today.
 <br><br>
 
 # 5. Contributors
+- [Tuomas Jääsalo](https://github.com/alcjzk)
 
 (add your name above if you contribute and a link to your github)
 

--- a/discord/commands/addgroup.js
+++ b/discord/commands/addgroup.js
@@ -34,41 +34,20 @@ async function collectArgsData(client, argsWithoutMentions, message) {
   return usersData;
 };
 
-exports.run = (client, message, args) => {
-  // We only allow this command to be run by DM or command channels (not categories).
-	if (!client.helpers.channelsAuth.onlyAuthorizeDmOrChannel(client, message)) return;
-  // Returns documentation.
-  if (client.helpers.shared.helpArg(args, message.channel, exports.help))
-    return;
+function createGroupChannel(client, message, parent_category, users_data) {
+	users_data.logins_list = users_data.logins_list.filter((x, i) => i === users_data.logins_list.indexOf(x))
+    users_data.logins_list.sort();
 
-  let argsWithoutMentions = args.filter(arg => !Discord.MessageMentions.USERS_PATTERN.test(arg));
-  let cad = collectArgsData;
-
-  cad(client, argsWithoutMentions, message).then( res => {
-    let usersData = res;
-    if (usersData.users.length <= 1) {
-      message.channel.send(exports.help.usage).catch(console.error);
-      return;
-    }
-    usersData.logins_list = usersData.logins_list.filter((x, i) => i === usersData.logins_list.indexOf(x))
-    usersData.logins_list.sort();
-
-    let channel_name = usersData.logins_list.join('_');
+    let channel_name = users_data.logins_list.join('_');
     channel_name = (channel_name.length > 100) ? channel_name.substr(0, 97) + '...' : channel_name;
 
-    const parent_category = client.config.guild.channels.cache.find(cat=> cat.name === client.config.privateGroupsCategory);
-    if (typeof parent_category === 'undefined' || !parent_category) {
-      message.channel.send(`Could not find the \`${client.config.privateGroupsCategory}\` category, please contact an administrator.`).catch(console.error);
-      return;
-    }
-
-    let permissionOverwrites = [];
+	let permissionOverwrites = [];
     // We deny every role to view this channel.
     client.config.guild.roles.cache.forEach(role => {
       permissionOverwrites.push({ id: role.id, type: "role", deny: ['VIEW_CHANNEL']})
     });
     // We allow author and every mentioned users to view this channel.
-    usersData.users.forEach(user => {
+    users_data.users.forEach(user => {
       permissionOverwrites.push({ id: user.id, allow: ['VIEW_CHANNEL', 'SEND_MESSAGES'],
                                 deny: ['MANAGE_CHANNELS', 'MANAGE_ROLES', 'MANAGE_WEBHOOKS', 'CREATE_INSTANT_INVITE', 'MANAGE_MESSAGES', 'SEND_TTS_MESSAGES'] });
     });
@@ -85,6 +64,31 @@ exports.run = (client, message, args) => {
       message.channel.send(`\`\`\`${error}\`\`\``);
       console.log(error); 
     });
+}
 
+exports.run = (client, message, args) => {
+  // We only allow this command to be run by DM or command channels (not categories).
+  if (!client.helpers.channelsAuth.onlyAuthorizeDmOrChannel(client, message)) return;
+  // Returns documentation.
+  if (client.helpers.shared.helpArg(args, message.channel, exports.help))
+    return;
+
+  let argsWithoutMentions = args.filter(arg => !Discord.MessageMentions.USERS_PATTERN.test(arg));
+  let cad = collectArgsData;
+
+  cad(client, argsWithoutMentions, message).then( res => {
+    let users_data = res;
+    if (users_data.users.length <= 1) {
+      message.channel.send(exports.help.usage).catch(console.error);
+      return;
+    }
+
+    const parent_category = client.config.guild.channels.cache.find(cat=> cat.name === client.config.privateGroupsCategory);
+    if (typeof parent_category === 'undefined' || !parent_category) {
+      message.channel.send(`Could not find the \`${client.config.privateGroupsCategory}\` category, please contact an administrator.`).catch(console.error);
+      return;
+    }
+
+	createGroupChannel(client, message, parent_category, users_data);
   });
 }

--- a/discord/commands/addgroup.js
+++ b/discord/commands/addgroup.js
@@ -104,7 +104,7 @@ exports.run = (client, message, args) => {
 			// Copy category specific permissions from the existing one.
 			permissionOverwrites: categories.first().permissionOverwrites,
 		})
-		.then(category => createGroupChannel(client, category, users_data, message))
+		.then(category => createGroupChannel(client, message, category, users_data))
 		.catch(error => console.log(error));
 	}
 	else

--- a/discord/helpers/channelsAuth.js
+++ b/discord/helpers/channelsAuth.js
@@ -5,7 +5,7 @@ exports.InPrivateGroupOnly = (channel) => {
     channel.send("This command should be run in a private group channel.")
     return false;
   }
-  if (!channel.parent || channel.parent.name !== config.privateGroupsCategory) {
+  if (!channel.parent || !channel.parent.name.startsWith(config.privateGroupsCategory)) {
     channel.send("This command should be run in a private group channel.")
     return false;
   }
@@ -22,8 +22,13 @@ exports.authorizedCommandLocations = (client, message) => {
 		if (client.config.authorizedCommandChannels.includes(channel.id))
 			return true;
 		// We allow commands to be sent through the commands allowed categories.
-		if (channel.parent && client.config.authorizedCommandCategories.includes(channel.parent.name))
-      return true;
+		if (channel.parent)
+		{
+			if (client.config.authorizedCommandCategories.includes(channel.parent.name))
+				return true;
+			if (channel.parent.name.startsWith(client.config.privateGroupsCategory))
+				return true;
+		}
   }
   return false;
 }


### PR DESCRIPTION
This PR fixes the issue of "too many channels in category" when creating group channels by:

- Creating new group channels under categories with the `privateGroupsCategory` as a prefix when possible
- Creating an additonal category when all existing ones are full

This should allow for adding group channels up to Discords per-server channel limit (500?).

Not included in this PR but I can add on later:
- Delete any generated category when its last child-channel has been deleted