### PR TITLE
Automatic thread creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ We welcome you to make this first step and make your first pull request today.
 
 # 5. Contributors
 - [Tuomas Jääsalo](https://github.com/alcjzk)
+- [Eemil Majuri](https://github.com/CrispLake)
 
 (add your name above if you contribute and a link to your github)
 

--- a/discord/events/messageCreate.js
+++ b/discord/events/messageCreate.js
@@ -11,7 +11,7 @@ const autoThreadEnabled = (client, message) => {
 
 const startThread = async (message) => {
   await message.startThread({
-    name: message.content.length > 0 ? message.content.substring(0, 99) : message.member.nickname + '\'s thread'
+    name: message.content.length > 0 ? message.content.substring(0, 99) : message.member.displayName + '\'s thread'
   })
 }
 

--- a/discord/events/messageCreate.js
+++ b/discord/events/messageCreate.js
@@ -11,7 +11,7 @@ const autoThreadEnabled = (client, message) => {
 
 const startThread = async (message) => {
   await message.startThread({
-    name: message.content.substring(0, 99)
+    name: message.content.length > 0 ? message.content.substring(0, 99) : message.member.nickname + '\'s thread'
   })
 }
 

--- a/discord/events/messageCreate.js
+++ b/discord/events/messageCreate.js
@@ -4,7 +4,7 @@ const { prefix } = require('../config.json');
 const autoThreadEnabled = (client, message) => {
   const channel = message.channel;
   if (channel.type === ChannelType.GuildText) {
-    if (client.config.autoThreadChannels && client.config.autoThreadChannels.includes(channel.id)) { return true; }
+    if (client.config.autoThreadChannels && client.config.autoThreadChannels.includes(channel.id)) return true;
   }
   return false;
 };

--- a/discord/events/messageCreate.js
+++ b/discord/events/messageCreate.js
@@ -1,11 +1,30 @@
-const { Events } = require('discord.js');
+const { Events, ChannelType } = require('discord.js');
 const { prefix } = require('../config.json');
+
+const autoThreadEnabled = (client, message) => {
+  const channel = message.channel;
+  if (channel.type === ChannelType.GuildText) {
+    if (client.config.autoThreadChannels && client.config.autoThreadChannels.includes(channel.id)) { return true; }
+  }
+  return false;
+};
+
+const startThread = async (message) => {
+  await message.startThread({
+    name: message.content.substring(0, 99)
+  })
+}
 
 module.exports = {
   name: Events.MessageCreate,
   async execute(message, client) {
     if (message.author.bot) return;
-    if (message.content.indexOf(prefix) !== 0) return;
+    if (message.content.indexOf(prefix) !== 0) {
+      if (autoThreadEnabled(client, message) === true) {
+        await startThread(message);
+      }
+      return;
+    }
     if (client.helpers.channelsAuth.authorizedCommandLocations(client, message) === false) return;
 
 

--- a/discord/events/messageCreate.js
+++ b/discord/events/messageCreate.js
@@ -1,9 +1,9 @@
-const { Events, ChannelType } = require('discord.js');
+const { Events, ChannelType, MessageType } = require('discord.js');
 const { prefix } = require('../config.json');
 
 const autoThreadEnabled = (client, message) => {
   const channel = message.channel;
-  if (channel.type === ChannelType.GuildText) {
+  if (channel.type === ChannelType.GuildText && message.type === MessageType.Default) {
     if (client.config.autoThreadChannels && client.config.autoThreadChannels.includes(channel.id)) return true;
   }
   return false;


### PR DESCRIPTION
By adding _"autoThreadChannels": ["CHANNEL ID"]_ in the config the bot will automatically start thread to all non command messages on specified channels and can keep the channel more organized