### PR TITLE
Enable private groups management

### DIFF
--- a/discord/client.js
+++ b/discord/client.js
@@ -6,6 +6,7 @@ const config = require('./config.json');
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildPresences,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.DirectMessages,

--- a/discord/commands/leavegroup.js
+++ b/discord/commands/leavegroup.js
@@ -1,0 +1,33 @@
+const config = require('../config.json');
+
+exports.help = {
+  name: 'leavegroup',
+  description: 'Removes you from the group you\'re in.',
+  usage: `‣ \`${config.prefix}leavegroup\` : Removes you from the group you\'re launching the command from.
+‣ \`${config.prefix}leavegroup help\` : Displays the usage.`,
+};
+
+exports.run = (client, message, args) => {
+  leaveGroup(client, message, message.channel, args).catch(console.error);
+};
+
+const leaveGroup = async (client, message, channel, args) => {
+  // Returns documentation.
+  if (client.helpers.shared.helpArg(args, channel, exports.help)) return;
+  // Must only be sent from a private group channel.
+  if (!client.helpers.channelsAuth.InPrivateGroupOnly(channel)) return;
+
+  const members = channel.members.filter(member =>
+    member.roles.cache.some(role =>
+      [config.studentRole, config.staffRole].includes(role.name)
+    )
+  );
+  if (members.size === 1) {
+    channel
+      .send(`You are the last person in this channel! Please use \`${config.prefix}deletegroup --sure\` instead, if this group is no longer needed.`)
+      .catch(console.error);
+    return;
+  }
+
+  await channel.permissionOverwrites.delete(message.author);
+};

--- a/discord/commands/removemember.js
+++ b/discord/commands/removemember.js
@@ -1,5 +1,5 @@
 const config = require('../config.json');
-const { PermissionsBitField, Collection, GuildMember } = require('discord.js');
+const { PermissionsBitField } = require('discord.js');
 
 exports.help = {
   name: 'removemember',
@@ -33,7 +33,7 @@ const removeMembers = async (client, message, channel, args) => {
   }
 
   let members = await Promise.all(args.map(async arg => {
-    const member = await fetchMember(arg);
+    const member = await client.helpers.shared.fetchMember(arg);
     if (!member) {
       channel.send(`Unknown user '${arg}'!`).catch(console.error);
       return null;
@@ -58,19 +58,4 @@ const removeMembers = async (client, message, channel, args) => {
     }
     await channel.permissionOverwrites.delete(member);
   }
-};
-
-const fetchMember = async login => {
-  let result = await config.guild.members.fetch({ query: login, limit: 1 });
-  if (result instanceof Collection) {
-    return result.find(member =>
-      member.displayName.split(' ')[0].toUpperCase() === login.toUpperCase()
-    );
-  }
-  else if (result instanceof GuildMember) {
-    if (result.displayName.split(' ')[0].toUpperCase() === login.toUpperCase())
-      return result;
-    return null;
-  }
-  else throw "Unexpected type";
 };

--- a/discord/commands/removemember.js
+++ b/discord/commands/removemember.js
@@ -1,0 +1,52 @@
+const config = require('../config.json');
+const { PermissionsBitField, Collection } = require('discord.js');
+
+exports.help = {
+  name: 'removemember',
+  description: 'Removes members from the group you\'re in.',
+  usage: `‣ \`${config.prefix}removemember help\` : Display the instructions.
+‣ \`${config.prefix}removemember login1 [ login2 .. ] --sure\` : Removes one of more members from the private group you're lauching the command from.`,
+};
+
+exports.run = (client, message, args) => {
+  const channel = message.channel;
+  // Returns documentation.
+  if (client.helpers.shared.helpArg(args, channel, exports.help)) { return; }
+  // Must only be sent from a private group channel.
+  if (!client.helpers.channelsAuth.InPrivateGroupOnly(channel)) return;
+
+  if (!message.channel.permissionsFor(message.author).has(PermissionsBitField.Flags.ManageChannels)) {
+    const msg = 'This command can only be used by channel owners\n';
+    message.channel.send(msg).catch(console.error);
+    return;
+  }
+
+  if (!args || args.length < 2 || args.pop() !== '--sure') {
+    channel.send(exports.help.usage).catch(console.error);
+    return;
+  }
+
+  console.log(args);
+
+  args.forEach(arg => {
+    config.guild.members.fetch({ query: arg, limit: 1 })
+      .then(result => {
+        let member;
+        if (result instanceof Collection)
+          member = result.first();
+        else
+          member = result;
+        if (member.id === message.author.id) {
+          // TODO:
+          const msg = "Wont remove self from group, please use `/leavegroup --sure` instead if this is intentional.";
+          message.channel.send(msg).catch(console.error);
+          return;
+        }
+        message.channel.permissionOverwrites.delete(member)
+          .catch(error => console.log(`removemember failed unexpectedly: ${error}`));
+      }).catch(error => {
+        // TODO: Failed to fetch member
+        console.log(error);
+      });
+  });
+};

--- a/discord/commands/removemember.js
+++ b/discord/commands/removemember.js
@@ -63,10 +63,14 @@ const removeMembers = async (client, message, channel, args) => {
 const fetchMember = async login => {
   let result = await config.guild.members.fetch({ query: login, limit: 1 });
   if (result instanceof Collection) {
-    return result.first();
+    return result.find(member =>
+      member.displayName.split(' ')[0].toUpperCase() === login.toUpperCase()
+    );
   }
   else if (result instanceof GuildMember) {
-    return result;
+    if (result.displayName.split(' ')[0].toUpperCase() === login.toUpperCase())
+      return result;
+    return null;
   }
   else throw "Unexpected type";
 };

--- a/discord/commands/removemember.js
+++ b/discord/commands/removemember.js
@@ -49,11 +49,11 @@ const removeMembers = async (client, message, channel, args) => {
   for (const member of unique_members) {
     if (member.id === message.author.id) {
       channel
-        .send(`Wont remove self from group, please use \`/leavegroup --sure\` instead if this is intentional.`)
+        .send(`Wont remove self from group, please use \`${config.prefix}leavegroup --sure\` instead if this is intentional.`)
         .catch(console.error);
       return;
     }
-    if (!channel.permissionOverwrites.resolve(member.id)) {
+    if (!channel.permissionOverwrites.cache.some(po => po.id === member.id)) {
       channel
         .send(`${member} not was not found in this channel!`)
         .catch(console.error);

--- a/discord/helpers/shared.js
+++ b/discord/helpers/shared.js
@@ -42,7 +42,7 @@ exports.addToPrivateGroupData = async (client, usersData, author, element) => {
 };
 
 exports.fetchMember = async login => {
-  let result = await config.guild.members.fetch({ query: login, limit: 1 });
+  let result = await config.guild.members.fetch({ query: login });
   if (result instanceof Collection) {
     return result.find(member =>
       member.displayName.split(' ')[0].toUpperCase() === login.toUpperCase()

--- a/discord/helpers/shared.js
+++ b/discord/helpers/shared.js
@@ -1,21 +1,21 @@
 const config = require("../config.json");
-const axios = require('axios');
+const { Collection, GuildMember } = require('discord.js');
 
 exports.helpArg = (args, channel, help) => {
   // Sends the description and usage of the function.
   if (args.length > 0 && args[0] === 'help') {
-		channel.send(`${help.description}\n${help.usage}`).catch(console.error);
-		return true;
+    channel.send(`${help.description}\n${help.usage}`).catch(console.error);
+    return true;
   }
   return false;
-}
+};
 
-exports.addToPrivateGroupData = async function (client, usersData, author, element) {
+exports.addToPrivateGroupData = async (client, usersData, author, element) => {
   let member = null;
   let login = null;
   if (typeof element === 'string') {
     try {
-      let res = await client.config.guild.members.fetch({query: element, limit: 1});
+      let res = await client.config.guild.members.fetch({ query: element, limit: 1 });
       if (res.size == 1) {
         member = res.last();
         if (member.roles.cache.some(role => [config.studentRole, config.staffRole].includes(role.name))) {
@@ -26,7 +26,7 @@ exports.addToPrivateGroupData = async function (client, usersData, author, eleme
           }
         }
       }
-    } catch(error) { console.log(error); }
+    } catch (error) { console.log(error); }
   } else {
     if (element.roles.cache.some(role => [config.studentRole, config.staffRole].includes(role.name))) {
       if (element.user.id != author.id && !(usersData.users.includes(element))) {
@@ -34,9 +34,24 @@ exports.addToPrivateGroupData = async function (client, usersData, author, eleme
           login = element.nickname ? element.nickname.split(" ")[0] : element.user.username.split(" ")[0];
           usersData.users.push(element.user);
           usersData.logins_list.push(login);
-        } catch(error) { console.log(error); }
+        } catch (error) { console.log(error); }
       }
     }
   }
   return usersData;
-}
+};
+
+exports.fetchMember = async login => {
+  let result = await config.guild.members.fetch({ query: login, limit: 1 });
+  if (result instanceof Collection) {
+    return result.find(member =>
+      member.displayName.split(' ')[0].toUpperCase() === login.toUpperCase()
+    );
+  }
+  else if (result instanceof GuildMember) {
+    if (result.displayName.split(' ')[0].toUpperCase() === login.toUpperCase())
+      return result;
+    return null;
+  }
+  else throw "Unexpected type";
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": ">=0.21.1",
         "dateformat": "^3.0.3",
-        "discord.js": "^14.9.0",
+        "discord.js": "^14.13.0",
         "express": "^4.17.1"
       },
       "devDependencies": {
@@ -21,65 +21,85 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.1.tgz",
-      "integrity": "sha512-CCcLwn/8ANhlAbhlE18fcaN0hfXTen53/JiwZs1t9oE/Cqa9maA8ZRarkCIsXF4J7J/MYnd0J6IsxeKsq+f6mw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/shapeshift": "^3.8.1",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/shapeshift": "^3.9.2",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.1"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.0.tgz",
-      "integrity": "sha512-suyVndkEAAWrGxyw/CPGdtXoRRU6AUNkibtnbJevQzpelkJh3Q1gQqWDpqf5i39CnAn5+LrN0YS+cULeEjq2Yw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.0.tgz",
-      "integrity": "sha512-Fc4MomalbP8HMKEMor3qUiboAKDtR7PSBoPjwm7WYghVRwgJlj5WYvUsriLsxeKk8+Qq2oy+HJlGTUkGvX0YnA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
       "dependencies": {
-        "discord-api-types": "^0.37.37"
+        "discord-api-types": "0.37.50"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.0.tgz",
-      "integrity": "sha512-r2HzmznRIo8IDGYBWqQfkEaGN1LrFfWQd3dSyC4tOpMU8nuVvFUEw6V/lwnG44jyOq+vgyDny2fxeUDMt9I4aQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
+      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/util": "^0.2.0",
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/util": "^1.0.1",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "discord-api-types": "^0.37.37",
-        "file-type": "^18.2.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.21.0"
+        "@sapphire/snowflake": "^3.5.1",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.50",
+        "magic-bytes.js": "^1.0.15",
+        "tslib": "^2.6.1",
+        "undici": "5.22.1"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
-      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
+      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "dependencies": {
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/rest": "^2.0.1",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/ws": "^8.5.5",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.50",
+        "tslib": "^2.6.1",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -274,9 +294,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.2.tgz",
-      "integrity": "sha512-NXpnJAsxN3/h9TqQPntOeVWZrpIuucqXI3IWF6tj2fWCoRLCuVK5wx7Dtg7pRrtkYfsMUbDqgKoX26vrC5iYfA==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.3.tgz",
+      "integrity": "sha512-WzKJSwDYloSkHoBbE8rkRW8UNKJiSRJ/P8NqJ5iVq7U2Yr/kriIBx2hW+wj2Z5e5EnXL1hgYomgaFsdK6b+zqQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
@@ -287,9 +307,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.2.tgz",
-      "integrity": "sha512-KJwlv5gkGjs1uFV7/xx81n3tqgBwBJvH94n1xDyH3q+JSmtsMeSleJffarEBfG2yAFeJiFA4BnGOK6FFPHc19g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -316,22 +336,29 @@
         "node": ">=6"
       }
     },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "node_modules/@types/node": {
-      "version": "18.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
+      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abbrev": {
@@ -935,31 +962,32 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.40",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.40.tgz",
-      "integrity": "sha512-LMALvtO+p6ERK8rwWoaI490NfIE/egbqjR4/rfLL1z9gQE1gqLiTpIUUDIunfAtKYzeH6ucyXhaXXWpfZh/Q6g=="
+      "version": "0.37.50",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
     },
     "node_modules/discord.js": {
-      "version": "14.9.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.9.0.tgz",
-      "integrity": "sha512-ygGms5xP4hG+QrrY9k7d/OYCzMltSMtdl/2Snzq/nLCiZo+Sna91Ulv9l0+B5Jd/Czcq37B7wJAnmja7GOa+bg==",
+      "version": "14.13.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
+      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.0",
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/rest": "^1.7.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "@types/ws": "^8.5.4",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/builders": "^1.6.5",
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/rest": "^2.0.1",
+        "@discordjs/util": "^1.0.1",
+        "@discordjs/ws": "^1.0.1",
+        "@sapphire/snowflake": "^3.5.1",
+        "@types/ws": "^8.5.5",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.21.0",
+        "tslib": "^2.6.1",
+        "undici": "5.22.1",
         "ws": "^8.13.0"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/doctrine": {
@@ -1381,22 +1409,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-type": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.3.0.tgz",
-      "integrity": "sha512-pkPZ5OGIq0TYb37b8bHDLNeQSe1H2KlaQ2ySGpJkkr2KZdaWsO4QhPzHA0mQcsUW2cSqJk+4gM/UyLz/UFbXdQ==",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1713,25 +1725,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -2038,6 +2031,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
+      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -2377,18 +2375,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "node_modules/peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -2531,34 +2517,6 @@
       },
       "bin": {
         "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -2793,14 +2751,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2808,22 +2758,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -2885,22 +2819,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -2919,9 +2837,9 @@
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2975,15 +2893,20 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -3052,11 +2975,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3222,51 +3140,68 @@
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.1.tgz",
-      "integrity": "sha512-CCcLwn/8ANhlAbhlE18fcaN0hfXTen53/JiwZs1t9oE/Cqa9maA8ZRarkCIsXF4J7J/MYnd0J6IsxeKsq+f6mw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
+      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
       "requires": {
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/shapeshift": "^3.8.1",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/shapeshift": "^3.9.2",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.1"
       }
     },
     "@discordjs/collection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.0.tgz",
-      "integrity": "sha512-suyVndkEAAWrGxyw/CPGdtXoRRU6AUNkibtnbJevQzpelkJh3Q1gQqWDpqf5i39CnAn5+LrN0YS+cULeEjq2Yw=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
     },
     "@discordjs/formatters": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.0.tgz",
-      "integrity": "sha512-Fc4MomalbP8HMKEMor3qUiboAKDtR7PSBoPjwm7WYghVRwgJlj5WYvUsriLsxeKk8+Qq2oy+HJlGTUkGvX0YnA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
+      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
       "requires": {
-        "discord-api-types": "^0.37.37"
+        "discord-api-types": "0.37.50"
       }
     },
     "@discordjs/rest": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.0.tgz",
-      "integrity": "sha512-r2HzmznRIo8IDGYBWqQfkEaGN1LrFfWQd3dSyC4tOpMU8nuVvFUEw6V/lwnG44jyOq+vgyDny2fxeUDMt9I4aQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
+      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
       "requires": {
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/util": "^0.2.0",
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/util": "^1.0.1",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "discord-api-types": "^0.37.37",
-        "file-type": "^18.2.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.21.0"
+        "@sapphire/snowflake": "^3.5.1",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.50",
+        "magic-bytes.js": "^1.0.15",
+        "tslib": "^2.6.1",
+        "undici": "5.22.1"
       }
     },
     "@discordjs/util": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
-      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
+      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA=="
+    },
+    "@discordjs/ws": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
+      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "requires": {
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/rest": "^2.0.1",
+        "@discordjs/util": "^1.0.1",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/ws": "^8.5.5",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.50",
+        "tslib": "^2.6.1",
+        "ws": "^8.13.0"
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3401,18 +3336,18 @@
       "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.2.tgz",
-      "integrity": "sha512-NXpnJAsxN3/h9TqQPntOeVWZrpIuucqXI3IWF6tj2fWCoRLCuVK5wx7Dtg7pRrtkYfsMUbDqgKoX26vrC5iYfA==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.3.tgz",
+      "integrity": "sha512-WzKJSwDYloSkHoBbE8rkRW8UNKJiSRJ/P8NqJ5iVq7U2Yr/kriIBx2hW+wj2Z5e5EnXL1hgYomgaFsdK6b+zqQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.2.tgz",
-      "integrity": "sha512-KJwlv5gkGjs1uFV7/xx81n3tqgBwBJvH94n1xDyH3q+JSmtsMeSleJffarEBfG2yAFeJiFA4BnGOK6FFPHc19g=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3429,23 +3364,26 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "@types/node": {
-      "version": "18.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@vladfrangu/async_event_emitter": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
+      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -3918,27 +3856,28 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "discord-api-types": {
-      "version": "0.37.40",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.40.tgz",
-      "integrity": "sha512-LMALvtO+p6ERK8rwWoaI490NfIE/egbqjR4/rfLL1z9gQE1gqLiTpIUUDIunfAtKYzeH6ucyXhaXXWpfZh/Q6g=="
+      "version": "0.37.50",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
+      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
     },
     "discord.js": {
-      "version": "14.9.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.9.0.tgz",
-      "integrity": "sha512-ygGms5xP4hG+QrrY9k7d/OYCzMltSMtdl/2Snzq/nLCiZo+Sna91Ulv9l0+B5Jd/Czcq37B7wJAnmja7GOa+bg==",
+      "version": "14.13.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
+      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
       "requires": {
-        "@discordjs/builders": "^1.6.0",
-        "@discordjs/collection": "^1.5.0",
-        "@discordjs/formatters": "^0.3.0",
-        "@discordjs/rest": "^1.7.0",
-        "@discordjs/util": "^0.2.0",
-        "@sapphire/snowflake": "^3.4.0",
-        "@types/ws": "^8.5.4",
-        "discord-api-types": "^0.37.37",
+        "@discordjs/builders": "^1.6.5",
+        "@discordjs/collection": "^1.5.3",
+        "@discordjs/formatters": "^0.3.2",
+        "@discordjs/rest": "^2.0.1",
+        "@discordjs/util": "^1.0.1",
+        "@discordjs/ws": "^1.0.1",
+        "@sapphire/snowflake": "^3.5.1",
+        "@types/ws": "^8.5.5",
+        "discord-api-types": "0.37.50",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.21.0",
+        "tslib": "^2.6.1",
+        "undici": "5.22.1",
         "ws": "^8.13.0"
       }
     },
@@ -4262,16 +4201,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "file-type": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.3.0.tgz",
-      "integrity": "sha512-pkPZ5OGIq0TYb37b8bHDLNeQSe1H2KlaQ2ySGpJkkr2KZdaWsO4QhPzHA0mQcsUW2cSqJk+4gM/UyLz/UFbXdQ==",
-      "requires": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4500,11 +4429,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.4",
@@ -4742,6 +4666,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "magic-bytes.js": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
+      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -4992,11 +4921,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
-    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -5092,26 +5016,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      }
-    },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "readdirp": {
@@ -5287,28 +5191,11 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
-      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -5351,15 +5238,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      }
-    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -5375,9 +5253,9 @@
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -5422,12 +5300,17 @@
       }
     },
     "undici": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
-      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
       "requires": {
         "busboy": "^1.6.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unique-string": {
       "version": "2.0.0",
@@ -5481,11 +5364,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "devDependencies": {
     "body-parser": "^1.19.0",
     "nodemon": "^2.0.6",
-	"eslint": "^8.39.0"
+    "eslint": "^8.39.0"
   },
   "dependencies": {
     "axios": ">=0.21.1",
     "dateformat": "^3.0.3",
-    "discord.js": "^14.9.0",
+    "discord.js": "^14.13.0",
     "express": "^4.17.1"
   }
 }


### PR DESCRIPTION
This PR adds the commands `leavegroup` and `removemember` for managing private groups, and modifies `addgroup` to grant `ManageChannels` and `ManageRoles` permissions to the user who created the group, since this is already the case in #sandbox.

---

As written the commands behave as follows:

`leavegroup` - Remove yourself from a private group.
- Blocked if the invoking user is the last normal user (has staff or student role) in the group to avoid orphaned groups, suggests using `deletegroup` instead.

`removemember` - Remove one or more members from a private group.
- Can only be used with `ManageChannels` permission, (granted to creator of new groups by default)
- Cannot be used to remove the invoker.
- Will not work in private groups created before this PR

**Minor changes:**
- Bump dependency `discordjs` `^14.9.0` -> `^14.13.0` for correct contents of `GuildMember::displayName`
- Implemented a `fetchMember` helper function for slighly more accurate login to discord-user matching
